### PR TITLE
[CARLS-52][CARLS-53][CARLS-54][CARLS-55] Create content infrastructure

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -77,10 +77,10 @@
 
 ## Phase 9: Content System (File-based)
 
-- [ ] [CARLS-52] Create content/ directory for MDX files
-- [ ] [CARLS-53] Create content/entries/ subdirectory
-- [ ] [CARLS-54] Create lib/content/mdx.ts with MDX file reading utilities
-- [ ] [CARLS-55] Add frontmatter parsing to lib/content/mdx.ts
+- [x] [CARLS-52] Create content/ directory for MDX files
+- [x] [CARLS-53] Create content/entries/ subdirectory
+- [x] [CARLS-54] Create lib/content/mdx.ts with MDX file reading utilities
+- [x] [CARLS-55] Add frontmatter parsing to lib/content/mdx.ts
 - [ ] [CARLS-56] Create first sample entry MDX: "first-day-anxiety.mdx"
 - [ ] [CARLS-57] Create second sample entry MDX: "discovered-usestate.mdx"
 - [ ] [CARLS-58] Create third sample entry MDX: "production-bug-nightmare.mdx"
@@ -127,4 +127,4 @@
 ---
 
 **Total Tasks:** 84
-**Current Progress:** 27/84 (32%)
+**Current Progress:** 31/84 (37%)

--- a/lib/content/mdx.ts
+++ b/lib/content/mdx.ts
@@ -1,0 +1,96 @@
+import fs from 'fs';
+import path from 'path';
+import matter from 'gray-matter';
+
+const contentDirectory = path.join(process.cwd(), 'content/entries');
+
+export interface FrontMatter {
+  title: string;
+  category: string;
+  anxietyLevel: 1 | 2 | 3 | 4 | 5;
+  date: string;
+  slug: string;
+  excerpt?: string;
+  tags?: string[];
+  carlLog?: string;
+  basilLog?: string;
+  lucyLog?: string;
+}
+
+export interface MdxEntry {
+  frontMatter: FrontMatter;
+  content: string;
+  slug: string;
+}
+
+/**
+ * Get all MDX files from the content/entries directory
+ */
+export function getAllMdxFiles(): string[] {
+  if (!fs.existsSync(contentDirectory)) {
+    return [];
+  }
+
+  const files = fs.readdirSync(contentDirectory);
+  return files.filter((file) => file.endsWith('.mdx'));
+}
+
+/**
+ * Read and parse an MDX file
+ */
+export function readMdxFile(filename: string): MdxEntry {
+  const filePath = path.join(contentDirectory, filename);
+  const fileContents = fs.readFileSync(filePath, 'utf8');
+
+  const { data, content } = matter(fileContents);
+
+  const slug = filename.replace(/\.mdx$/, '');
+
+  return {
+    frontMatter: {
+      ...(data as Omit<FrontMatter, 'slug'>),
+      slug,
+    },
+    content,
+    slug,
+  };
+}
+
+/**
+ * Get all entries with their frontmatter and content
+ */
+export function getAllEntries(): MdxEntry[] {
+  const files = getAllMdxFiles();
+  const entries = files.map((filename) => readMdxFile(filename));
+
+  // Sort by date, newest first
+  return entries.sort((a, b) => {
+    const dateA = new Date(a.frontMatter.date);
+    const dateB = new Date(b.frontMatter.date);
+    return dateB.getTime() - dateA.getTime();
+  });
+}
+
+/**
+ * Get a single entry by slug
+ */
+export function getEntryBySlug(slug: string): MdxEntry | null {
+  const filename = `${slug}.mdx`;
+  const filePath = path.join(contentDirectory, filename);
+
+  if (!fs.existsSync(filePath)) {
+    return null;
+  }
+
+  return readMdxFile(filename);
+}
+
+/**
+ * Get entries by category
+ */
+export function getEntriesByCategory(category: string): MdxEntry[] {
+  const allEntries = getAllEntries();
+  return allEntries.filter(
+    (entry) => entry.frontMatter.category.toLowerCase() === category.toLowerCase()
+  );
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "date-fns": "^4.1.0",
+        "gray-matter": "^4.0.3",
         "lucide-react": "^0.544.0",
         "next": "15.5.4",
         "react": "19.1.0",
@@ -3414,6 +3415,19 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "license": "BSD-2-Clause",
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/esquery": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.6.0.tgz",
@@ -3472,6 +3486,18 @@
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
       "license": "MIT"
+    },
+    "node_modules/extend-shallow": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+      "integrity": "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==",
+      "license": "MIT",
+      "dependencies": {
+        "is-extendable": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
@@ -3817,6 +3843,43 @@
       "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/gray-matter": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/gray-matter/-/gray-matter-4.0.3.tgz",
+      "integrity": "sha512-5v6yZd4JK3eMI3FqqCouswVqwugaA9r4dNZB1wwcmrD02QkV5H0y7XBQW8QwQqEaZY1pM9aqORSORhJRdNK44Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-yaml": "^3.13.1",
+        "kind-of": "^6.0.2",
+        "section-matter": "^1.0.0",
+        "strip-bom-string": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=6.0"
+      }
+    },
+    "node_modules/gray-matter/node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "license": "MIT",
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "node_modules/gray-matter/node_modules/js-yaml": {
+      "version": "3.14.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
     },
     "node_modules/has-bigints": {
       "version": "1.1.0",
@@ -4310,6 +4373,15 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/is-extendable": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+      "integrity": "sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -4725,6 +4797,15 @@
       "license": "MIT",
       "dependencies": {
         "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/kind-of": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+      "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/language-subtag-registry": {
@@ -6901,6 +6982,19 @@
       "integrity": "sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA==",
       "license": "MIT"
     },
+    "node_modules/section-matter": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/section-matter/-/section-matter-1.0.0.tgz",
+      "integrity": "sha512-vfD3pmTzGpufjScBh50YHKzEu2lxBWhVEHsNGoEXmCmn2hKGfeNLYMzCJpe8cD7gqX7TJluOVpBkAequ6dgMmA==",
+      "license": "MIT",
+      "dependencies": {
+        "extend-shallow": "^2.0.1",
+        "kind-of": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/semver": {
       "version": "7.7.2",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
@@ -7176,6 +7270,12 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/stable-hash": {
       "version": "0.0.5",
       "resolved": "https://registry.npmjs.org/stable-hash/-/stable-hash-0.0.5.tgz",
@@ -7361,6 +7461,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/strip-bom-string": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom-string/-/strip-bom-string-1.0.0.tgz",
+      "integrity": "sha512-uCC2VHvQRYu+lMh4My/sFNmF2klFymLX1wHJeXnbEJERpV/ZsVuonzerjfrGpIGF7LBVa1O7i9kjiWvJiFck8g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/strip-json-comments": {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "date-fns": "^4.1.0",
+    "gray-matter": "^4.0.3",
     "lucide-react": "^0.544.0",
     "next": "15.5.4",
     "react": "19.1.0",


### PR DESCRIPTION
## Summary

Creates the content infrastructure for MDX blog entries, including directory structure and utility functions for reading and parsing MDX files with frontmatter.

## Related Issue

Closes #113
Closes #114
Closes #115
Closes #116

## Changes

- Created `content/entries/` directory for MDX blog post files
- Created `lib/content/mdx.ts` with MDX file reading utilities:
  - `FrontMatter` interface with support for carlLog, basilLog, lucyLog fields
  - `getAllMdxFiles()` - lists all .mdx files in content/entries
  - `readMdxFile()` - parses single MDX file with frontmatter
  - `getAllEntries()` - gets all entries sorted by date (newest first)
  - `getEntryBySlug()` - retrieves single entry by slug
  - `getEntriesByCategory()` - filters entries by category
- Installed `gray-matter` for frontmatter parsing
- Updated TODO.md to mark CARLS-52 through CARLS-55 as complete

---

Co-Authored-By: Basil <noreply@anthropic.com>