### PR TITLE
[CARLS-65] Update Lucy to be powered by Claude

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -102,12 +102,12 @@ export default function AboutPage() {
               <p className="mt-2">
                 Powered by{' '}
                 <a
-                  href="https://openai.com/chatgpt"
+                  href="https://claude.ai"
                   target="_blank"
                   rel="noopener noreferrer"
                   className="text-pink-600 hover:text-pink-800 underline"
                 >
-                  ChatGPT
+                  Claude
                 </a>
               </p>
               <p className="text-gray-600 mt-4">Specialties:</p>


### PR DESCRIPTION
## Summary

Updated Lucy's "Powered by" link from ChatGPT to Claude, reflecting Carl's preference for honesty over validation.

## Related Issue

Related to #126 (CARLS-65 - already closed, this is a follow-up update)

## Changes

- Changed About page: Lucy now links to claude.ai instead of openai.com/chatgpt

---

Co-Authored-By: Basil <noreply@anthropic.com>