### PR TITLE
[CARLS-61][CARLS-62] Create data layer for blog entries

### DIFF
--- a/lib/data/entries.ts
+++ b/lib/data/entries.ts
@@ -1,0 +1,31 @@
+import { getAllEntries, getEntryBySlug as getMdxEntry, getEntriesByCategory as getMdxByCategory } from '@/lib/content/mdx';
+import type { MdxEntry } from '@/lib/content/mdx';
+
+/**
+ * Get all blog entries, sorted by date (newest first)
+ */
+export function getEntries(): MdxEntry[] {
+  return getAllEntries();
+}
+
+/**
+ * Get a single entry by slug
+ */
+export function getEntryBySlug(slug: string): MdxEntry | null {
+  return getMdxEntry(slug);
+}
+
+/**
+ * Get entries filtered by category
+ */
+export function getEntriesByCategory(category: string): MdxEntry[] {
+  return getMdxByCategory(category);
+}
+
+/**
+ * Get recent entries (limit to N most recent)
+ */
+export function getRecentEntries(limit: number = 5): MdxEntry[] {
+  const allEntries = getAllEntries();
+  return allEntries.slice(0, limit);
+}


### PR DESCRIPTION
## Summary

Created data access layer for blog entries with functions to retrieve and filter MDX posts.

## Related Issue

Closes #122
Closes #123

## Changes

- Created `lib/data/entries.ts` with:
  - `getEntries()` - Get all entries sorted by date
  - `getEntryBySlug()` - Get single entry by slug
  - `getEntriesByCategory()` - Filter entries by category
  - `getRecentEntries()` - Get N most recent entries
- All functions use existing MDX utilities from `lib/content/mdx.ts`

---

Co-Authored-By: Basil <noreply@anthropic.com>