### PR TITLE
[CARLS-64] Display recent entries on home page

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -66,14 +66,14 @@
 
 ## Phase 8: Entries Pages
 
-- [ ] [CARLS-44] Create app/entries/page.tsx for all entries listing
+- [x] [CARLS-44] Create app/entries/page.tsx for all entries listing
 - [ ] [CARLS-45] Create app/entries/loading.tsx
 - [ ] [CARLS-46] Create app/entries/error.tsx
-- [ ] [CARLS-47] Create app/entries/[slug]/page.tsx for single entry with MDX rendering
+- [x] [CARLS-47] Create app/entries/[slug]/page.tsx for single entry with MDX rendering (includes three-perspective blog format)
 - [ ] [CARLS-48] Create app/entries/[slug]/loading.tsx
 - [ ] [CARLS-49] Create app/entries/[slug]/error.tsx
-- [ ] [CARLS-50] Add generateStaticParams to app/entries/[slug]/page.tsx
-- [ ] [CARLS-51] Add generateMetadata to app/entries/[slug]/page.tsx
+- [x] [CARLS-50] Add generateStaticParams to app/entries/[slug]/page.tsx
+- [x] [CARLS-51] Add generateMetadata to app/entries/[slug]/page.tsx
 
 ## Phase 9: Content System (File-based)
 
@@ -81,18 +81,18 @@
 - [x] [CARLS-53] Create content/entries/ subdirectory
 - [x] [CARLS-54] Create lib/content/mdx.ts with MDX file reading utilities
 - [x] [CARLS-55] Add frontmatter parsing to lib/content/mdx.ts
-- [ ] [CARLS-56] Create first sample entry MDX: "first-day-anxiety.mdx"
+- [x] [CARLS-56] Create first blog post: "procrastination-disguised-as-productivity.mdx"
 - [ ] [CARLS-57] Create second sample entry MDX: "discovered-usestate.mdx"
 - [ ] [CARLS-58] Create third sample entry MDX: "production-bug-nightmare.mdx"
 
 ## Phase 10: Data Access Layer (File-based)
 
-- [ ] [CARLS-59] Create lib/data/categories.ts with hardcoded categories array
+- [x] [CARLS-59] Create lib/data/categories.ts with hardcoded categories array
 - [ ] [CARLS-60] Add getCategoryBySlug function to lib/data/categories.ts
-- [ ] [CARLS-61] Create lib/data/entries.ts with file-based getEntries function
-- [ ] [CARLS-62] Add getEntryBySlug function to lib/data/entries.ts
-- [ ] [CARLS-63] Add getEntriesByCategory function to lib/data/entries.ts
-- [ ] [CARLS-64] Add getRecentEntries function to lib/data/entries.ts
+- [x] [CARLS-61] Create lib/data/entries.ts with file-based getEntries function
+- [x] [CARLS-62] Add getEntryBySlug function to lib/data/entries.ts
+- [x] [CARLS-63] Add getEntriesByCategory function to lib/data/entries.ts
+- [x] [CARLS-64] Add getRecentEntries function to lib/data/entries.ts and display on home page
 
 ## Phase 11: Additional Pages
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,7 +1,12 @@
 import Link from 'next/link';
 import { MusicPlayer } from '@/components/music-player';
+import { getRecentEntries } from '@/lib/data/entries';
+import { categoryConfig } from '@/lib/config/categories';
+import type { CategorySlug } from '@/lib/types/category';
+import { format } from 'date-fns';
 
 export default function Home() {
+  const recentEntries = getRecentEntries(3);
   return (
     <div className="min-h-screen bg-gray-50">
       {/* Hero Section */}
@@ -54,16 +59,96 @@ export default function Home() {
         </div>
       </section>
 
-      {/* Recent Entries Section - Placeholder for now */}
+      {/* Recent Entries Section */}
       <section className="max-w-4xl mx-auto px-6 py-16">
         <h2 className="font-primary font-bold text-3xl text-gray-900 mb-8">
           Recent Entries
         </h2>
-        <div className="pixel-card p-8 text-center">
-          <p className="font-primary text-gray-600">
-            No entries yet. Start writing to see them here! 📝
-          </p>
-        </div>
+        {recentEntries.length === 0 ? (
+          <div className="pixel-card p-8 text-center">
+            <p className="font-primary text-gray-600">
+              No entries yet. Start writing to see them here!
+            </p>
+          </div>
+        ) : (
+          <div className="space-y-6">
+            {recentEntries.map((entry) => {
+              const Icon = categoryConfig[entry.frontMatter.category as CategorySlug]?.icon;
+              const categoryColor = categoryConfig[entry.frontMatter.category as CategorySlug]?.color;
+
+              return (
+                <Link
+                  key={entry.slug}
+                  href={`/entries/${entry.slug}`}
+                  className="block pixel-card p-6 hover:shadow-lg transition-shadow"
+                >
+                  {/* Category & Date */}
+                  <div className="flex items-center gap-3 mb-3">
+                    {Icon && (
+                      <Icon
+                        className="w-4 h-4"
+                        style={{ color: categoryColor }}
+                      />
+                    )}
+                    <span
+                      className="font-mono text-xs font-semibold"
+                      style={{ color: categoryColor }}
+                    >
+                      {entry.frontMatter.category}
+                    </span>
+                    <span className="text-gray-400">•</span>
+                    <time className="font-mono text-xs text-gray-500">
+                      {format(new Date(entry.frontMatter.date), 'MMM d, yyyy')}
+                    </time>
+                  </div>
+
+                  {/* Title */}
+                  <h3 className="font-primary font-bold text-xl text-gray-900 mb-2">
+                    {entry.frontMatter.title}
+                  </h3>
+
+                  {/* Excerpt */}
+                  {entry.frontMatter.excerpt && (
+                    <p className="text-gray-600 text-sm mb-3">
+                      {entry.frontMatter.excerpt}
+                    </p>
+                  )}
+
+                  {/* Tags */}
+                  {entry.frontMatter.tags && entry.frontMatter.tags.length > 0 && (
+                    <div className="flex flex-wrap gap-2">
+                      {entry.frontMatter.tags.slice(0, 3).map((tag) => (
+                        <span
+                          key={tag}
+                          className="font-mono text-xs px-2 py-1 bg-gray-100 text-gray-600 rounded"
+                        >
+                          #{tag}
+                        </span>
+                      ))}
+                      {entry.frontMatter.tags.length > 3 && (
+                        <span className="font-mono text-xs text-gray-500">
+                          +{entry.frontMatter.tags.length - 3} more
+                        </span>
+                      )}
+                    </div>
+                  )}
+                </Link>
+              );
+            })}
+          </div>
+        )}
+
+        {/* View All Link */}
+        {recentEntries.length > 0 && (
+          <div className="mt-8 text-center">
+            <Link
+              href="/entries"
+              className="inline-flex items-center gap-2 font-mono text-sm text-gray-600 hover:text-gray-900 transition-colors"
+            >
+              View all entries →
+            </Link>
+          </div>
+        )}
       </section>
     </div>
   );


### PR DESCRIPTION
## Summary

Added recent entries section to home page using getRecentEntries function.

## Related Issue

Closes #125

## Changes

- Display 3 most recent blog entries on home page
- Show category icon, date, title, excerpt, and tags for each entry
- Include "View all entries" link when entries exist
- Fallback message when no entries available
- Updated TODO.md to reflect completed tasks

Co-Authored-By: Basil <noreply@anthropic.com>